### PR TITLE
Make ss_opt_linux executable when building container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -59,6 +59,8 @@
 	  // Use 'postCreateCommand' to run commands after the container is created.
 	  "postCreateCommand": "Rscript .devcontainer/install.r",
 	  "postAttachCommand": "sudo rstudio-server start",
+	  "postCreateCommand": "sudo chmod a+x Model-Runs/Template_files/'one sex'/ss_opt_linux",
+	  "postCreateCommand": "sudo chmod a+x Model-Runs/Template_files/'two sex'/ss_opt_linux",
 	  "remoteUser": "rstudio"
 	
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -59,8 +59,7 @@
 	  // Use 'postCreateCommand' to run commands after the container is created.
 	  "postCreateCommand": "Rscript .devcontainer/install.r",
 	  "postAttachCommand": "sudo rstudio-server start",
-	  "postCreateCommand": "sudo chmod a+x Model-Runs/Template_files/'one sex'/ss_opt_linux",
-	  "postCreateCommand": "sudo chmod a+x Model-Runs/Template_files/'two sex'/ss_opt_linux",
+	  "postCreateCommand": "sudo chmod a+x Model-Runs/Template_files/'one sex'/ss_opt_linux && sudo chmod a+x Model-Runs/Template_files/'two sex'/ss_opt_linux",
 	  "remoteUser": "rstudio"
 	
 }


### PR DESCRIPTION
Note that this is file path sensitive. If you move the `ss_opt_linux` file, you will need to update the path in the `postCreateCommand` line to match the new path. 